### PR TITLE
GUI-less service applications need jquery, and cater for STDOUT loggers

### DIFF
--- a/config/initializers/websocket_server.rb
+++ b/config/initializers/websocket_server.rb
@@ -2,7 +2,11 @@ require 'rubyception/websocket_server'
 require 'rubyception/subscriber'
 require 'rubyception/catcher'
 
-::Rails.logger.auto_flushing = true
+if ::Rails.logger.respond_to?(:auto_flushing=)
+  ::Rails.logger.auto_flushing = true
+end
+
+.auto_flushing = true
 Rubyception::WebsocketServer.sockets = []
 Rubyception::WebsocketServer.new
 

--- a/rubyception.gemspec
+++ b/rubyception.gemspec
@@ -23,5 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'em-websocket'
   s.add_dependency 'compass'
   s.add_dependency 'coffee-script'
+  s.add_dependency 'jquery-rails'
   s.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
When included as an engine in a GUI less back end service, rubyception fails to display without jquery. This adds it explicitly.

Also, logging to stdout (syslog) means the autoflushing setting is not available, so should not be attempted.
